### PR TITLE
Removed body horizontal scroll (macOS)

### DIFF
--- a/styles/index.js
+++ b/styles/index.js
@@ -12,7 +12,6 @@ export default `
   body {
     margin: 0;
     padding: 0;
-    width: 100vw;
     height: 100vh;
     color: ${colors.white};
     background-color: ${colors.black};


### PR DESCRIPTION
Hi Xavier! This is a friendly PR 😁

I've removed the horizontal scroll when vertical scroll is shown due to the `width: 100vh` CSS property of the body tag. No need for this property since the body is a block and always get 100% of the horizontal space by default. 

![horizontal-scroll](https://cloud.githubusercontent.com/assets/7225802/26151328/a21cf6c4-3b02-11e7-9f8b-50aef65fde22.gif)

The horizontal scroll is shown because `width: vh` takes all the width including the space of the vertical scrollbar, that's why the horizontal scrollbar is shown only when the vertical scroll is active.

The bug was detected and fixed in these browsers (all macOS, not tested in Windows or Linux):

- Chrome 58
- Firefox 53
- Safari 10.1
- Opera 45

PS: I've been waiting to use React Storybook for a while, looks amazing!

